### PR TITLE
tiger: correctly check base32 size

### DIFF
--- a/tiger/tiger.go
+++ b/tiger/tiger.go
@@ -83,9 +83,11 @@ func (h *Hash) FromBase32(s string) error {
 	b, err := base32Enc.DecodeString(s)
 	if err != nil {
 		return err
-	} else if n := copy((*h)[:], b); n != len(h) {
-		return fmt.Errorf("wrong base32 size: %d vs %d", n, len(h))
 	}
+	if len(b) != Size {
+		return fmt.Errorf("wrong base32 encoded size: %d vs %d", len(b), Size)
+	}
+	copy((*h)[:], b)
 	return nil
 }
 


### PR DESCRIPTION
FromBase32() allows wrongly-sized strings to be converted without trigging errors.
It checks the result of copy(), that returns the minimum size of the two arguments.

If a string contains a hash < 24 bytes, an error is triggered.
If a string contains a hash > 24 bytes, copy() returns 24 and an error is not triggered.

PS: this PR influences go-dcpp's CID in some cases, since it's based on FromBase32:
https://github.com/direct-connect/go-dcpp/blob/4d51d486500d994de5f9e88412e376a7b3d0d498/adc/types/types.go#L105

CID should have never been based on hash since "Clients must be prepared to handle CIDs of varying lengths", ie of lengths <= tiger size.
So with or without the patch your CID actually triggers an error when it receives a value < 24, which is a bug.

