### PR TITLE
tiger: add leaves.ToTreeHash()

### DIFF
--- a/tiger/tth.go
+++ b/tiger/tth.go
@@ -28,10 +28,10 @@ func TreeLeaves(r io.Reader) (lvl Leaves, err error) {
 	return
 }
 
-// ToTreeHash converts leaves into a hash.
-func (in Leaves) ToTreeHash() Hash {
+// TreeHash converts leaves into a hash.
+func (in Leaves) TreeHash() Hash {
 	// deep copy leaves since they must be modified in order to compute the hash
-	lvl := append(in[:0:0], in...)
+	lvl := append([]Hash{}, in...)
 	buf := make([]byte, 2*Size+1)
 
 	for len(lvl) > 1 {

--- a/tiger/tth.go
+++ b/tiger/tth.go
@@ -28,6 +28,32 @@ func TreeLeaves(r io.Reader) (lvl Leaves, err error) {
 	return
 }
 
+// ToTreeHash converts leaves into a hash.
+func (in Leaves) ToTreeHash() Hash {
+	// deep copy leaves since they must be modified in order to compute the hash
+	lvl := append(in[:0:0], in...)
+	buf := make([]byte, 2*Size+1)
+
+	for len(lvl) > 1 {
+		for i := 0; i < len(lvl); i += 2 {
+			if i+1 >= len(lvl) {
+				lvl[i/2] = lvl[i]
+			} else {
+				buf[0] = 0x01
+				copy(buf[1:], lvl[i][:])
+				copy(buf[1+Size:], lvl[i+1][:])
+				lvl[i/2] = HashBytes(buf)
+			}
+		}
+		n := len(lvl) / 2
+		if len(lvl)%2 != 0 {
+			n++
+		}
+		lvl = lvl[:n]
+	}
+	return lvl[0]
+}
+
 // TreeHash calculates a Tiger Tree Hash of a reader.
 func TreeHash(r io.Reader) (root Hash, err error) {
 	var (

--- a/tiger/tth_test.go
+++ b/tiger/tth_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 var tthCases = []struct {
-	data []byte
+	data   []byte
 	leaves tiger.Leaves
-	hash string
+	hash   string
 }{
 	{
 		[]byte{},
@@ -83,7 +83,7 @@ var tthCases = []struct {
 		tiger.Leaves([]tiger.Hash{
 			tiger.MustParseBase32("BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI"),
 			tiger.MustParseBase32("CZQUWH3IYXBF5L3BGYUGZHASSMXU647IP2IKE4Y"),
-			}),
+		}),
 		`CDYY2OW6F6DTGCH3Q6NMSDLSRV7PNMAL3CED3DA`,
 	},
 }
@@ -95,6 +95,19 @@ func TestTTHLeaves(t *testing.T) {
 			t.Fatal(err)
 		} else if reflect.DeepEqual(lvl, c.leaves) == false {
 			t.Errorf("wrong leaves on %d: %v vs %v", i+1, c.leaves, lvl)
+		}
+	}
+}
+
+func TestTTHLeavesToTreeHash(t *testing.T) {
+	for i, c := range tthCases {
+		lvl, err := tiger.TreeLeaves(bytes.NewReader(c.data))
+		if err != nil {
+			t.Fatal(err)
+		}
+		h := lvl.ToTreeHash()
+		if h != tiger.MustParseBase32(c.hash) {
+			t.Errorf("wrong hash on %d: %s vs %s", i+1, c.hash, h)
 		}
 	}
 }

--- a/tiger/tth_test.go
+++ b/tiger/tth_test.go
@@ -105,7 +105,7 @@ func TestTTHLeavesToTreeHash(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		h := lvl.ToTreeHash()
+		h := lvl.TreeHash()
 		if h != tiger.MustParseBase32(c.hash) {
 			t.Errorf("wrong hash on %d: %s vs %s", i+1, c.hash, h)
 		}


### PR DESCRIPTION
A client must provide both leaves and TTH for every file.
the most efficient way to do so is computing first the leaves and then the TTH from the leaves.

In this way we provide the most efficient way to compute TTH directly though TreeHash(), and the most efficient way to compute TTH from leaves through leaves.ToTreeHash().
