### PR TITLE
lineproto: support zlib

### DIFF
--- a/lineproto/reader.go
+++ b/lineproto/reader.go
@@ -59,7 +59,7 @@ func (c *zlibSwitchableReader) Read(buf []byte) (int, error) {
 	}
 }
 
-func (c *zlibSwitchableReader) ActivateCompression() error {
+func (c *zlibSwitchableReader) ActivateZlib() error {
 	if c.activeReader == c.zlibReader {
 		return fmt.Errorf("zlib already activated")
 	}
@@ -151,7 +151,7 @@ func (r *Reader) ReadLine() ([]byte, error) {
 	}
 }
 
-// ActivateCompression activates zlib deflating.
-func (r *Reader) ActivateCompression() error {
-	return r.in.ActivateCompression()
+// ActivateZlib activates zlib deflating.
+func (r *Reader) ActivateZlib() error {
+	return r.in.ActivateZlib()
 }

--- a/lineproto/reader.go
+++ b/lineproto/reader.go
@@ -79,9 +79,9 @@ func (c *zlibSwitchableReader) ActivateZlib() error {
 // Reader is a line reader that supports the zlib on/off switching procedure
 // required by hub-to-client and client-to-client connections.
 type Reader struct {
-	in    *zlibSwitchableReader
-	delim byte
-	mutex sync.Mutex
+	in     *zlibSwitchableReader
+	delim  byte
+	mutex  sync.Mutex
 	buffer []byte
 
 	// Safe can be set to disable internal mutex.
@@ -103,8 +103,8 @@ func NewReader(in io.Reader, delim byte) *Reader {
 
 	// third reader is the line reader
 	return &Reader{
-		in:    l2,
-		delim: delim,
+		in:     l2,
+		delim:  delim,
 		buffer: make([]byte, maxLine),
 	}
 }

--- a/lineproto/reader.go
+++ b/lineproto/reader.go
@@ -79,9 +79,9 @@ func (c *zlibSwitchableReader) ActivateZlib() error {
 // Reader is a line reader that supports the zlib on/off switching procedure
 // required by hub-to-client and client-to-client connections.
 type Reader struct {
-	in     *zlibSwitchableReader
-	delim  byte
-	mutex  sync.Mutex
+	in    *zlibSwitchableReader
+	delim byte
+	mutex sync.Mutex
 	buffer []byte
 
 	// Safe can be set to disable internal mutex.
@@ -103,8 +103,8 @@ func NewReader(in io.Reader, delim byte) *Reader {
 
 	// third reader is the line reader
 	return &Reader{
-		in:     l2,
-		delim:  delim,
+		in:    l2,
+		delim: delim,
 		buffer: make([]byte, maxLine),
 	}
 }
@@ -113,7 +113,7 @@ func NewReader(in io.Reader, delim byte) *Reader {
 // a delimiter and is in the connection encoding. The buffer is only valid until the next
 // call to Read or ReadLine.
 func (r *Reader) ReadLine() ([]byte, error) {
-	if r.Safe == false {
+	if !r.Safe {
 		r.mutex.Lock()
 		defer r.mutex.Unlock()
 	}

--- a/lineproto/reader.go
+++ b/lineproto/reader.go
@@ -77,7 +77,7 @@ func (c *zlibSwitchableReader) ActivateCompression() error {
 	return nil
 }
 
-// Reader is a line reader that supports zlib on/off switching procedure
+// Reader is a line reader that supports the zlib on/off switching procedure
 // required by NMDC hub-to-client and client-to-client connections.
 type Reader struct {
 	in    *zlibSwitchableReader

--- a/lineproto/reader.go
+++ b/lineproto/reader.go
@@ -78,7 +78,7 @@ func (c *zlibSwitchableReader) ActivateCompression() error {
 }
 
 // Reader is a line reader that supports the zlib on/off switching procedure
-// required by NMDC hub-to-client and client-to-client connections.
+// required by hub-to-client and client-to-client connections.
 type Reader struct {
 	in    *zlibSwitchableReader
 	delim byte

--- a/lineproto/reader_test.go
+++ b/lineproto/reader_test.go
@@ -2,8 +2,8 @@ package lineproto
 
 import (
 	"bytes"
-	"reflect"
 	"testing"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReader(t *testing.T) {
@@ -18,30 +18,18 @@ func TestReader(t *testing.T) {
 
 	l1Expected := []byte("$ZOn|")
 	l1, err := r.ReadLine()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if reflect.DeepEqual(l1, l1Expected) == false {
-		t.Fatalf("l1 error: %v vs %v", l1, l1Expected)
-	}
+	require.NoError(t, err)
+	require.Equal(t, l1, l1Expected)
 
 	r.ActivateCompression()
 
 	l2Expected := []byte("$OtherCommand test|")
 	l2, err := r.ReadLine()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if reflect.DeepEqual(l2, l2Expected) == false {
-		t.Fatalf("l2 error: %v vs %v", l2, l2Expected)
-	}
+	require.NoError(t, err)
+	require.Equal(t, l2, l2Expected)
 
 	l3Expected := []byte("$Uncompressed|")
 	l3, err := r.ReadLine()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if reflect.DeepEqual(l3, l3Expected) == false {
-		t.Fatalf("l3 error: %v vs %v", l3, l3Expected)
-	}
+	require.NoError(t, err)
+	require.Equal(t, l3, l3Expected)
 }

--- a/lineproto/reader_test.go
+++ b/lineproto/reader_test.go
@@ -2,8 +2,8 @@ package lineproto
 
 import (
 	"bytes"
-	"testing"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 func TestReader(t *testing.T) {

--- a/lineproto/reader_test.go
+++ b/lineproto/reader_test.go
@@ -21,7 +21,7 @@ func TestReader(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, l1, l1Expected)
 
-	r.ActivateCompression()
+	r.ActivateZlib()
 
 	l2Expected := []byte("$OtherCommand test|")
 	l2, err := r.ReadLine()

--- a/lineproto/reader_test.go
+++ b/lineproto/reader_test.go
@@ -1,0 +1,47 @@
+package lineproto
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestReader(t *testing.T) {
+	var byts []byte
+	byts = append(byts, []byte("$ZOn|")...)
+	byts = append(byts, []byte{120, 156, 82, 241, 47, 201, 72, 45, 114,
+		206, 207, 205, 77, 204, 75, 81, 40, 73, 45,
+		46, 169, 1, 4, 0, 0, 255, 255, 69, 30, 7, 66}...)
+	byts = append(byts, []byte("$Uncompressed|")...)
+
+	r := NewReader(bytes.NewReader(byts), '|')
+
+	l1Expected := []byte("$ZOn|")
+	l1, err := r.ReadLine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reflect.DeepEqual(l1, l1Expected) == false {
+		t.Fatalf("l1 error: %v vs %v", l1, l1Expected)
+	}
+
+	r.ActivateCompression()
+
+	l2Expected := []byte("$OtherCommand test|")
+	l2, err := r.ReadLine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reflect.DeepEqual(l2, l2Expected) == false {
+		t.Fatalf("l2 error: %v vs %v", l2, l2Expected)
+	}
+
+	l3Expected := []byte("$Uncompressed|")
+	l3, err := r.ReadLine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reflect.DeepEqual(l3, l3Expected) == false {
+		t.Fatalf("l3 error: %v vs %v", l3, l3Expected)
+	}
+}


### PR DESCRIPTION
This is hard but necessary.

Zlib is used in both NMDC and ADC:
* for transferring files
* for hub-to-client communication, between $ZOn| and a zlib EOF.

Zlib is also (IMHO) the main feature that indicates that the protocol is old and conceived a long time ago: its activation and deactivation on a certain message depends on the content of the previous message.
Parallel parsing and processing of messages (basically the main feature of Go) is not possible, messages have to be FIRST parsed and then processed, because the following message could be compressed and require deflating.

This PR replicates the solution i implemented in dctk, and introduces a 3-levels line reader:
* in the first level, bytes are buffered
* in the second level, bytes are deflated if compression is active
* in the third level, bytes are read until the delimiter, byte by byte, STRICTLY without buffering

Please test carefully this patch with the hub and feel free to propose changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/direct-connect/go-dc/8)
<!-- Reviewable:end -->
