### PR TITLE
Fix Zlib performance regression

### DIFF
--- a/lineproto/reader.go
+++ b/lineproto/reader.go
@@ -1,7 +1,7 @@
 package lineproto
 
 import (
-	"bufio"
+	"bytes"
 	"compress/flate"
 	"compress/zlib"
 	"errors"
@@ -15,8 +15,10 @@ const (
 	maxLine = readBuf * 16
 )
 
-var errorBufferExhausted = errors.New("message buffer exhausted")
-var errorZlibAlreadyActive = errors.New("zlib already activated")
+var (
+	errBufferExhausted   = errors.New("message is too long")
+	errZlibAlreadyActive = errors.New("zlib already activated")
+)
 
 type ErrProtocolViolation struct {
 	Err error
@@ -26,66 +28,93 @@ func (e *ErrProtocolViolation) Error() string {
 	return fmt.Sprintf("protocol error: %v", e.Err)
 }
 
-// zlibSwitchableReader is a zlib reader that can be switched on at any time.
-// the flate.Reader requirement ensures that zlib read only the necessary bytes,
-// leaving the remainings in the previous buffer.
-type zlibSwitchableReader struct {
-	r                  flate.Reader
-	zlibReader         io.ReadCloser
-	zlibActive         bool
-	zlibBufferedReader io.ByteReader
-}
+var (
+	_ io.Reader    = (*bufReader)(nil)
+	_ flate.Reader = (*bufReader)(nil)
+)
 
-func newZlibSwitchableReader(r flate.Reader) *zlibSwitchableReader {
-	return &zlibSwitchableReader{
-		r: r,
+func newBufReader(r io.Reader) *bufReader {
+	return &bufReader{
+		r: r, buf: make([]byte, 0, readBuf),
 	}
 }
 
-func (c *zlibSwitchableReader) ActivateZlib() error {
-	if c.zlibActive == true {
-		return errorZlibAlreadyActive
-	}
-	c.zlibActive = true
+// bufReader is a copy of bufio.Reader that allows to expose the underlying buffer.
+type bufReader struct {
+	r   io.Reader
+	buf []byte // pre-allocated, never grows
+	off int    // offset into buf
+}
 
-	// allocate a new reader
-	if c.zlibReader == nil {
-		var err error
-		c.zlibReader, err = zlib.NewReader(c.r)
-		if err != nil {
-			return err
+func (r *bufReader) Reset(rd io.Reader) {
+	r.r = rd
+	r.off = 0
+}
+
+func (r *bufReader) peek() error {
+	n, err := r.r.Read(r.buf[:cap(r.buf)])
+	if n == 0 && err != nil {
+		return err
+	}
+	// suppress error if we get any data
+	// it will be returned on the next call
+	r.buf = r.buf[:n]
+	r.off = 0
+	return nil
+}
+
+func (r *bufReader) ReadByte() (byte, error) {
+	if r.off >= len(r.buf) {
+		if err := r.peek(); err != nil {
+			return 0, err
 		}
-		c.zlibBufferedReader = bufio.NewReaderSize(c.zlibReader, readBuf)
-		return nil
 	}
-
-	// reuse previous reader
-	return c.zlibReader.(zlib.Resetter).Reset(c.r, nil)
+	b := r.buf[r.off]
+	r.off++
+	return b, nil
 }
 
-func (c *zlibSwitchableReader) ReadByte() (byte, error) {
-	if c.zlibActive == false {
-		return c.r.ReadByte()
+func (r *bufReader) Read(p []byte) (int, error) {
+	if r.off < len(r.buf) {
+		n := copy(p, r.buf[r.off:])
+		r.off += n
+		return n, nil
 	}
+	// bypass the buffer
+	return r.r.Read(p)
+}
 
-	res, err := c.zlibBufferedReader.ReadByte()
-
-	// zlib EOF: disable zlib and read again
-	if err == io.EOF {
-		c.zlibActive = false
-		return c.r.ReadByte()
+func (r *bufReader) Scan(delim byte) ([]byte, bool, error) {
+	if r.off >= len(r.buf) {
+		if err := r.peek(); err != nil {
+			return nil, false, err
+		}
 	}
-
-	return res, err
+	buf := r.buf[r.off:]
+	i := bytes.IndexByte(buf, delim)
+	if i < 0 {
+		r.off += len(buf)
+		// need more bytes
+		return buf, true, nil
+	}
+	// found in the buffer
+	buf = buf[:i+1]
+	r.off += len(buf)
+	return buf, false, nil
 }
 
 // Reader is a line reader that supports the zlib on/off switching procedure
 // required by hub-to-client and client-to-client connections.
 type Reader struct {
-	r      *zlibSwitchableReader
-	delim  byte
-	mutex  sync.Mutex
-	buffer []byte
+	delim byte
+
+	mu         sync.Mutex
+	cur        *bufReader // current reader; set either to original or compressed
+	original   *bufReader // original reader with buffer
+	zlibOn     bool
+	zlib       io.ReadCloser // resettable zlib reader stored for reuse
+	compressed *bufReader    // compressed reader; stored for reuse
+	line       []byte        // buffered line; up to maxLine bytes
 
 	// Safe can be set to disable internal mutex.
 	Safe bool
@@ -98,17 +127,12 @@ type Reader struct {
 
 // NewReader allocates a Reader.
 func NewReader(r io.Reader, delim byte) *Reader {
-	// first reader is bufio.Reader
-	l1 := bufio.NewReaderSize(r, readBuf)
-
-	// second reader is zlibSwitchableReader
-	l2 := newZlibSwitchableReader(l1)
-
-	// third reader is the line reader
+	br := newBufReader(r)
 	return &Reader{
-		r:      l2,
-		delim:  delim,
-		buffer: make([]byte, maxLine),
+		delim:    delim,
+		original: br,
+		cur:      br,
+		line:     make([]byte, readBuf),
 	}
 }
 
@@ -117,45 +141,68 @@ func NewReader(r io.Reader, delim byte) *Reader {
 // call to Read or ReadLine.
 func (r *Reader) ReadLine() ([]byte, error) {
 	if !r.Safe {
-		r.mutex.Lock()
-		defer r.mutex.Unlock()
+		r.mu.Lock()
+		defer r.mu.Unlock()
 	}
+	r.line = r.line[:0]
 
-	offset := 0
 	for {
-		if offset >= len(r.buffer) {
-			return nil, errorBufferExhausted
+		if len(r.line) >= maxLine {
+			return nil, errBufferExhausted
 		}
-
-		// transfer one byte at a time
-		var err error
-		r.buffer[offset], err = r.r.ReadByte()
+		pref, more, err := r.cur.Scan(r.delim)
+		if err == io.EOF && r.zlibOn {
+			// if compression was enabled, we need to switch back to original reader
+			r.cur = r.original
+			continue
+		}
+		r.line = append(r.line, pref...)
 		if err != nil {
-			return nil, err
-		}
-		offset++
-
-		if r.buffer[offset-1] != r.delim {
+			return r.line, err
+		} else if more {
 			continue
 		}
 
+		line := r.line
 		if r.OnLine != nil {
-			// OnLine() error
-			if ok, err := r.OnLine(r.buffer[:offset]); err != nil {
+			if ok, err := r.OnLine(line); err != nil {
 				return nil, err
-
-				// OnLine() commanded to drop buffer
 			} else if !ok {
-				offset = 0
+				// hook commands to drop the message
+				r.line = r.line[:0]
 				continue
 			}
 		}
 
-		return r.buffer[:offset], nil
+		return line, nil
 	}
 }
 
 // ActivateZlib activates zlib deflating.
 func (r *Reader) ActivateZlib() error {
-	return r.r.ActivateZlib()
+	if r.zlibOn {
+		return errZlibAlreadyActive
+	}
+	r.zlibOn = true
+
+	if r.zlib != nil {
+		err := r.zlib.(zlib.Resetter).Reset(r.original, nil)
+		if err != nil {
+			return err
+		}
+	} else {
+		rc, err := zlib.NewReader(r.original)
+		if err != nil {
+			return err
+		}
+		r.zlib = rc
+	}
+
+	if r.compressed != nil {
+		r.compressed.Reset(r.zlib)
+	} else {
+		r.compressed = newBufReader(r.zlib)
+	}
+	r.cur = r.compressed
+	return nil
 }

--- a/lineproto/reader.go
+++ b/lineproto/reader.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	readBuf = 2048 // TCP MTU is ~1500
-	maxLine = readBuf * 8
+	maxLine = readBuf * 16
 )
 
 var errorBufferExhausted = errors.New("message buffer exhausted")

--- a/lineproto/reader_test.go
+++ b/lineproto/reader_test.go
@@ -16,21 +16,17 @@ func TestReader(t *testing.T) {
 
 	r := NewReader(bytes.NewReader(byts), '|')
 
-	l1Expected := []byte("$ZOn|")
-	l1, err := r.ReadLine()
-	require.NoError(t, err)
-	require.Equal(t, l1, l1Expected)
+	expect := func(exp string) {
+		line, err := r.ReadLine()
+		require.NoError(t, err)
+		require.Equal(t, exp, string(line))
+	}
 
-	err = r.ActivateZlib()
+	expect("$ZOn|")
+
+	err := r.ActivateZlib()
 	require.NoError(t, err)
 
-	l2Expected := []byte("$OtherCommand test|")
-	l2, err := r.ReadLine()
-	require.NoError(t, err)
-	require.Equal(t, l2, l2Expected)
-
-	l3Expected := []byte("$Uncompressed|")
-	l3, err := r.ReadLine()
-	require.NoError(t, err)
-	require.Equal(t, l3, l3Expected)
+	expect("$OtherCommand test|")
+	expect("$Uncompressed|")
 }

--- a/lineproto/reader_test.go
+++ b/lineproto/reader_test.go
@@ -21,7 +21,8 @@ func TestReader(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, l1, l1Expected)
 
-	r.ActivateZlib()
+	err = r.ActivateZlib()
+	require.NoError(t, err)
 
 	l2Expected := []byte("$OtherCommand test|")
 	l2, err := r.ReadLine()


### PR DESCRIPTION
Fix Zlib performance regression by manually buffering data. Fixes #9 

Performance comparison with the latest version:
```
benchmark             old ns/op     new ns/op     delta
BenchmarkReader-4     93300098      11941476      -87.20%

benchmark             old allocs     new allocs     delta
BenchmarkReader-4     7              6              -14.29%

benchmark             old bytes     new bytes     delta
BenchmarkReader-4     35372         4374          -87.63%
```

Comparison with the previous version (pre #8):
```
benchmark             old ns/op     new ns/op     delta
BenchmarkReader-4     13904844      11941476      -14.12%

benchmark             old allocs     new allocs     delta
BenchmarkReader-4     6              6              +0.00%

benchmark             old bytes     new bytes     delta
BenchmarkReader-4     4950          4374          -11.64%
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/direct-connect/go-dc/10)
<!-- Reviewable:end -->
