### PR TITLE
Fix one more edge case for chat message parsing

### DIFF
--- a/nmdc/chat.go
+++ b/nmdc/chat.go
@@ -59,12 +59,20 @@ func (m *ChatMessage) UnmarshalNMDC(dec *TextDecoder, data []byte) error {
 			off  = 0
 			base = 0
 		)
+		// found next '>' character and check that the next one is a whitespace
 		for base < len(data) {
 			j := bytes.IndexByte(data[base:], '>')
 			if j < 0 {
-				return &ErrProtocolViolation{
-					Err: errors.New("name in chat message should have a closing token"),
+				// no '>' characters followed by a space
+				// use the last one (which is base-1)
+				if base == 0 {
+					return &ErrProtocolViolation{
+						Err: errors.New("name in chat message should have a closing token"),
+					}
 				}
+				i = base - 1
+				off = 1
+				break
 			}
 			if base+j == len(data)-1 {
 				i = j

--- a/nmdc/reader_test.go
+++ b/nmdc/reader_test.go
@@ -81,11 +81,25 @@ var casesReader = []struct {
 		},
 	},
 	{
-		name:  "chat",
-		input: "<b>b>> text|",
+		name:  "chat no space",
+		input: "<bob>text msg|<fred> msg2|",
 		exp: []Message{
 			&ChatMessage{
-				Name: "b>b>",
+				Name: "bob",
+				Text: "text msg",
+			},
+			&ChatMessage{
+				Name: "fred",
+				Text: "msg2",
+			},
+		},
+	},
+	{
+		name:  "chat",
+		input: "<b >b >> text|",
+		exp: []Message{
+			&ChatMessage{
+				Name: "b >b >",
 				Text: "text",
 			},
 		},


### PR DESCRIPTION
There are cases in the wild when hubs send no space after the username delimiter in NMDC protocol. This PR fixes parsing of such messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/direct-connect/go-dc/11)
<!-- Reviewable:end -->
