### PR TITLE
nmdc: trim delimiter faster

### DIFF
--- a/nmdc/reader.go
+++ b/nmdc/reader.go
@@ -115,6 +115,10 @@ func (r *Reader) readMsgTo(ptr *Message) error {
 		line, err := r.ReadLine()
 		if err != nil {
 			return err
+		} else if n := len(line); n == 0 || line[n-1] != '|' {
+			return &ErrProtocolViolation{
+				Err: errors.New("no message delimiter"),
+			}
 		}
 		if bytes.ContainsAny(line, "\x00") {
 			return &ErrProtocolViolation{

--- a/nmdc/reader.go
+++ b/nmdc/reader.go
@@ -121,7 +121,7 @@ func (r *Reader) readMsgTo(ptr *Message) error {
 				Err: errors.New("message should not contain null characters"),
 			}
 		}
-		line = bytes.TrimSuffix(line, []byte("|"))
+		line = line[:len(line)-1] // trim delimiter
 		if len(line) == 0 {
 			// keep-alive
 			if r.OnKeepAlive != nil {


### PR DESCRIPTION
a line always ends with the delimiter, so it is safe to trim it by cutting directly the slice.