### PR TITLE
nmdc: Support other ConnectToMe flags

### DIFF
--- a/nmdc/connect.go
+++ b/nmdc/connect.go
@@ -3,6 +3,7 @@ package nmdc
 import (
 	"bytes"
 	"errors"
+	"fmt"
 )
 
 func init() {
@@ -10,9 +11,19 @@ func init() {
 	RegisterMessage(&RevConnectToMe{})
 }
 
+type CTMKind int
+
+const (
+	CTMActive = CTMKind(iota)
+	CTMPassiveReq
+	CTMPassiveResp
+)
+
 type ConnectToMe struct {
 	Targ    string
+	Src     string
 	Address string
+	Kind    CTMKind
 	Secure  bool
 }
 
@@ -21,13 +32,39 @@ func (m *ConnectToMe) Type() string {
 }
 
 func (m *ConnectToMe) MarshalNMDC(enc *TextEncoder, buf *bytes.Buffer) error {
+	if m.Targ == "" {
+		return fmt.Errorf("ConnectToMe target should be set")
+	}
 	if err := Name(m.Targ).MarshalNMDC(enc, buf); err != nil {
 		return err
 	}
 	buf.WriteByte(' ')
 	buf.WriteString(m.Address)
+	switch m.Kind {
+	case CTMActive:
+	// nothing
+	case CTMPassiveReq:
+		buf.WriteByte('N')
+	case CTMPassiveResp:
+		buf.WriteByte('R')
+	default:
+		return fmt.Errorf("unknown ConnectToMe kind: %v", m.Kind)
+	}
 	if m.Secure {
 		buf.WriteByte('S')
+	}
+	if m.Kind != CTMPassiveReq {
+		if m.Src != "" {
+			return fmt.Errorf("only passive ConnectToMe requests should have a source")
+		}
+		return nil
+	}
+	if m.Src == "" {
+		return fmt.Errorf("passive ConnectToMe requests should have a source")
+	}
+	buf.WriteByte(' ')
+	if err := Name(m.Src).MarshalNMDC(enc, buf); err != nil {
+		return err
 	}
 	return nil
 }
@@ -41,12 +78,33 @@ func (m *ConnectToMe) UnmarshalNMDC(dec *TextDecoder, data []byte) error {
 	if err := name.UnmarshalNMDC(dec, data[:i]); err != nil {
 		return err
 	}
-	addr := data[i+1:]
+	data = data[i+1:]
 	m.Targ = string(name)
+
+	if i := bytes.IndexByte(data, ' '); i >= 0 {
+		name = ""
+		if err := name.UnmarshalNMDC(dec, data[i+1:]); err != nil {
+			return err
+		}
+		data = data[:i]
+		m.Src = string(name)
+	}
+	addr := data
 
 	if l := len(addr); l != 0 && addr[l-1] == 'S' {
 		addr = addr[:l-1]
 		m.Secure = true
+	}
+	m.Kind = CTMActive
+	if l := len(addr); l != 0 {
+		switch addr[l-1] {
+		case 'N':
+			m.Kind = CTMPassiveReq
+			addr = addr[:l-1]
+		case 'R':
+			m.Kind = CTMPassiveResp
+			addr = addr[:l-1]
+		}
 	}
 	m.Address = string(addr)
 	return nil

--- a/nmdc/messages_test.go
+++ b/nmdc/messages_test.go
@@ -266,6 +266,7 @@ var casesUnmarshal = []struct {
 		msg: &ConnectToMe{
 			Targ:    "john",
 			Address: "192.168.1.2:412",
+			Kind:    CTMActive,
 			Secure:  false,
 		},
 	},
@@ -275,6 +276,49 @@ var casesUnmarshal = []struct {
 		msg: &ConnectToMe{
 			Targ:    "john",
 			Address: "192.168.1.2:412",
+			Kind:    CTMActive,
+			Secure:  true,
+		},
+	},
+	{
+		typ:  "ConnectToMe",
+		data: `john 192.168.1.2:412N peter`,
+		msg: &ConnectToMe{
+			Targ:    "john",
+			Src:     "peter",
+			Address: "192.168.1.2:412",
+			Kind:    CTMPassiveReq,
+			Secure:  false,
+		},
+	},
+	{
+		typ:  "ConnectToMe",
+		data: `john 192.168.1.2:412NS peter`,
+		msg: &ConnectToMe{
+			Targ:    "john",
+			Src:     "peter",
+			Address: "192.168.1.2:412",
+			Kind:    CTMPassiveReq,
+			Secure:  true,
+		},
+	},
+	{
+		typ:  "ConnectToMe",
+		data: `john 192.168.1.2:412R`,
+		msg: &ConnectToMe{
+			Targ:    "john",
+			Address: "192.168.1.2:412",
+			Kind:    CTMPassiveResp,
+			Secure:  false,
+		},
+	},
+	{
+		typ:  "ConnectToMe",
+		data: `john 192.168.1.2:412RS`,
+		msg: &ConnectToMe{
+			Targ:    "john",
+			Address: "192.168.1.2:412",
+			Kind:    CTMPassiveResp,
 			Secure:  true,
 		},
 	},


### PR DESCRIPTION
Support `ConnectToMe` flags for NAT traversal.

Fixes #16

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/direct-connect/go-dc/18)
<!-- Reviewable:end -->
