### PR TITLE
nmdc: Support commands from TTHS extension

### DIFF
--- a/nmdc/extensions.go
+++ b/nmdc/extensions.go
@@ -144,6 +144,7 @@ const (
 	ExtMinislots        = "Minislots"
 	ExtTTHL             = "TTHL"
 	ExtTTHF             = "TTHF"
+	ExtTTHS             = "TTHS"
 	ExtZLIG             = "ZLIG"
 	ExtACTM             = "ACTM"
 	ExtBZList           = "BZList"

--- a/nmdc/messages_test.go
+++ b/nmdc/messages_test.go
@@ -375,6 +375,24 @@ var casesUnmarshal = []struct {
 		},
 	},
 	{
+		typ:  "SA",
+		name: "Short TTH search (active)",
+		data: `LWPNACQDBZRYXW3VHJVCJ64QBZNGHOHHHZWCLNQ 1.2.3.4:412`,
+		msg: &TTHSearchActive{
+			TTH:     tiger.MustParseBase32("LWPNACQDBZRYXW3VHJVCJ64QBZNGHOHHHZWCLNQ"),
+			Address: "1.2.3.4:412",
+		},
+	},
+	{
+		typ:  "SP",
+		name: "Short TTH search (passive)",
+		data: `LWPNACQDBZRYXW3VHJVCJ64QBZNGHOHHHZWCLNQ user`,
+		msg: &TTHSearchPassive{
+			TTH:  tiger.MustParseBase32("LWPNACQDBZRYXW3VHJVCJ64QBZNGHOHHHZWCLNQ"),
+			User: "user",
+		},
+	},
+	{
 		typ:  "SR",
 		name: "dir result",
 		data: "User6 dir1\\dir2\\pictures 0/4\x05Testhub (192.168.1.1)",


### PR DESCRIPTION
Support short TTH search commands from [TTHS](https://github.com/direct-connect/protocols/blob/master/nmdc/nmdc.md#tths-sa-and-sp) extension.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/direct-connect/go-dc/19)
<!-- Reviewable:end -->
