### PR TITLE
nmdc: slightly improve performance by using WriteByte instead of WriteString

### DIFF
--- a/nmdc/chat.go
+++ b/nmdc/chat.go
@@ -199,7 +199,7 @@ func (m *MCTo) MarshalNMDC(enc *TextEncoder, buf *bytes.Buffer) error {
 		return err
 	}
 
-	buf.WriteString(" ")
+	buf.WriteByte(' ')
 	if err := String(m.Text).MarshalNMDC(enc, buf); err != nil {
 		return err
 	}

--- a/nmdc/connect.go
+++ b/nmdc/connect.go
@@ -122,7 +122,7 @@ func (m *RevConnectToMe) MarshalNMDC(enc *TextEncoder, buf *bytes.Buffer) error 
 	if err := Name(m.From).MarshalNMDC(enc, buf); err != nil {
 		return err
 	}
-	buf.WriteString(" ")
+	buf.WriteByte(' ')
 	if err := Name(m.To).MarshalNMDC(enc, buf); err != nil {
 		return err
 	}

--- a/nmdc/extensions.go
+++ b/nmdc/extensions.go
@@ -50,7 +50,7 @@ func (m *Supports) MarshalNMDC(_ *TextEncoder, buf *bytes.Buffer) error {
 	buf.Grow(n)
 	for i, ext := range m.Ext {
 		if i != 0 {
-			buf.WriteString(" ")
+			buf.WriteByte(' ')
 		}
 		buf.WriteString(ext)
 	}

--- a/nmdc/lock.go
+++ b/nmdc/lock.go
@@ -46,7 +46,7 @@ func (m *Lock) MarshalNMDC(_ *TextEncoder, buf *bytes.Buffer) error {
 	}
 	if m.Ref != "" {
 		if m.PK == "" {
-			buf.WriteString(" ")
+			buf.WriteByte(' ')
 		}
 		buf.WriteString("Ref=")
 		buf.WriteString(m.Ref)

--- a/nmdc/ping.go
+++ b/nmdc/ping.go
@@ -70,7 +70,7 @@ func (m *HubINFO) MarshalNMDC(enc *TextEncoder, buf *bytes.Buffer) error {
 		buf.WriteString(m.Soft.Name)
 	} else {
 		buf.WriteString(m.Soft.Name)
-		buf.WriteString(" ")
+		buf.WriteByte(' ')
 		buf.WriteString(m.Soft.Version)
 	}
 

--- a/nmdc/user.go
+++ b/nmdc/user.go
@@ -114,7 +114,7 @@ func (m *MyINFO) MarshalNMDC(enc *TextEncoder, buf *bytes.Buffer) error {
 	if err := Name(m.Name).MarshalNMDC(enc, buf); err != nil {
 		return err
 	}
-	buf.WriteString(" ")
+	buf.WriteByte(' ')
 	if err := String(m.Desc).MarshalNMDC(enc, buf); err != nil {
 		return err
 	}

--- a/nmdc/user_list.go
+++ b/nmdc/user_list.go
@@ -98,7 +98,7 @@ func (m *UserIP) MarshalNMDC(enc *TextEncoder, buf *bytes.Buffer) error {
 		if err := Name(a.Name).MarshalNMDC(enc, buf); err != nil {
 			return err
 		}
-		buf.WriteString(" ")
+		buf.WriteByte(' ')
 		buf.WriteString(a.IP)
 		buf.WriteString("$$")
 	}


### PR DESCRIPTION
Hey, i finally found some spare time to complete the merging of dctoolkit and go-dc, in order to produce a full base library for DC-related development.

I've transferred most of the protocol implementation from dctoolkit to my fork of go-dc, and i'm going to send every patch i've produced such that they can be reviewed and merged, starting by this one.

Benchmarks show that WriteByte() is slightly faster than WriteString(), this patch uses the first when possible.
