### PR TITLE
nmdc: fix case when OpList is empty and an array with an empty string is returned instead of an empty array

### DIFF
--- a/nmdc/user_list.go
+++ b/nmdc/user_list.go
@@ -62,11 +62,13 @@ func (m Names) MarshalNMDC(enc *TextEncoder, buf *bytes.Buffer) error {
 }
 
 func (m *Names) UnmarshalNMDC(dec *TextDecoder, data []byte) error {
+	data = bytes.TrimSuffix(data, []byte("$$"))
+
 	if len(data) == 0 {
 		*m = nil
 		return nil
 	}
-	data = bytes.TrimSuffix(data, []byte("$$"))
+
 	sub := bytes.Split(data, []byte("$$"))
 	list := make([]string, 0, len(sub))
 	for _, b := range sub {

--- a/nmdc/user_list_test.go
+++ b/nmdc/user_list_test.go
@@ -6,6 +6,27 @@ import (
 
 var userListCases = []casesMessageEntry{
 	{
+		typ:  "OpList",
+		data: "$$",
+		msg: &OpList{
+			Names: nil,
+		},
+	},
+	{
+		typ:  "OpList",
+		data: "Op 1$$",
+		msg: &OpList{
+			Names: []string{"Op 1"},
+		},
+	},
+	{
+		typ:  "OpList",
+		data: "Op 1$$Op 2$$",
+		msg: &OpList{
+			Names: []string{"Op 1", "Op 2"},
+		},
+	},
+	{
 		typ:  "UserIP",
 		data: `john doe 192.168.1.2$$user 2 192.168.1.3$$`,
 		msg: &UserIP{


### PR DESCRIPTION
In case of an empty OpList, the current implementation returns a list with a single item, with zero length:
```
&OpList{
    Names: []string{""},
},
```

while it should return:
```
&OpList{
    Names: nil,
},
```

This patch fixes the problem and adds unit tests.
