### PR TITLE
adc: support file compression

### DIFF
--- a/adc/files.go
+++ b/adc/files.go
@@ -1,5 +1,11 @@
 package adc
 
+import (
+	"bytes"
+	"errors"
+	"strconv"
+)
+
 const (
 	FileListBZIP = "files.xml.bz2"
 )
@@ -19,15 +25,83 @@ func (GetInfoRequest) Cmd() MsgType {
 	return MsgType{'G', 'F', 'I'}
 }
 
+var (
+	_ Marshaler   = GetRequest{}
+	_ Unmarshaler = (*GetRequest)(nil)
+)
+
 type GetRequest struct {
-	Type  string `adc:"#"`
-	Path  string `adc:"#"`
-	Start int64  `adc:"#"`
-	Bytes int64  `adc:"#"`
+	Type       string
+	Path       string
+	Start      int64
+	Bytes      int64
+	Compressed bool
 }
 
 func (GetRequest) Cmd() MsgType {
 	return MsgType{'G', 'E', 'T'}
+}
+
+func (m GetRequest) MarshalADC(buf *bytes.Buffer) error {
+	buf.Write(escape(m.Type))
+	buf.WriteByte(' ')
+	buf.Write(escape(m.Path))
+	buf.WriteByte(' ')
+	buf.WriteString(strconv.FormatInt(m.Start, 10))
+	buf.WriteByte(' ')
+	buf.WriteString(strconv.FormatInt(m.Bytes, 10))
+	if m.Compressed {
+		buf.Write([]byte(" ZL1"))
+	}
+	return nil
+}
+
+func (m *GetRequest) UnmarshalADC(data []byte) error {
+	i := bytes.IndexByte(data, ' ')
+	if i < 0 {
+		return errors.New("ADCGET: missing separator after field 1")
+	}
+	typ, data := data[:i], data[i+1:]
+	m.Type = unescape(typ)
+
+	i = bytes.IndexByte(data, ' ')
+	if i < 0 {
+		return errors.New("ADCGET: missing separator after field 2")
+	}
+	path, data := data[:i], data[i+1:]
+	m.Path = unescape(path)
+
+	i = bytes.IndexByte(data, ' ')
+	if i < 0 {
+		return errors.New("ADCGET: missing separator after field 3")
+	}
+	start, data := data[:i], data[i+1:]
+	var err error
+	m.Start, err = strconv.ParseInt(string(start), 10, 64)
+	if err != nil {
+		return errors.New("ADCGET: unable to parse field 3")
+	}
+
+	i = bytes.IndexByte(data, ' ')
+	var length []byte
+	if i < 0 {
+		length, data = data[:], nil
+	} else {
+		length, data = data[:i], data[i+1:]
+	}
+	m.Bytes, err = strconv.ParseInt(string(length), 10, 64)
+	if err != nil {
+		return errors.New("ADCGET: unable to parse field 4")
+	}
+
+	if len(data) > 0 {
+		if !bytes.Equal(data, []byte("ZL1")) {
+			return errors.New("ADCGET: invalid field 5")
+		}
+		m.Compressed = true
+	}
+
+	return nil
 }
 
 type GetResponse GetRequest

--- a/adc/marshal_test.go
+++ b/adc/marshal_test.go
@@ -127,6 +127,39 @@ var casesDecode = []struct {
 			Category: adc.CategoryHub | adc.CategoryUser,
 		},
 	},
+	{
+		"get file",
+		`file TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 124 12352`,
+		&adc.GetRequest{
+			Type:       "file",
+			Path:       "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
+			Start:      124,
+			Bytes:      12352,
+			Compressed: false,
+		},
+	},
+	{
+		"get file compressed",
+		`file TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 124 12352 ZL1`,
+		&adc.GetRequest{
+			Type:       "file",
+			Path:       "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
+			Start:      124,
+			Bytes:      12352,
+			Compressed: true,
+		},
+	},
+	{
+		"get tthl",
+		`tthl TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 124 12352`,
+		&adc.GetRequest{
+			Type:       "tthl",
+			Path:       "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
+			Start:      124,
+			Bytes:      12352,
+			Compressed: false,
+		},
+	},
 }
 
 func sidp(s string) *types.SID {
@@ -222,6 +255,36 @@ var casesEncode = []struct {
 			Category: adc.CategoryHub | adc.CategoryUser,
 		},
 		`ADCH++/Hub\smanagement/Reload\sscripts TTHMSG\s+reload\n CT3`,
+	},
+	{
+		&adc.GetRequest{
+			Type:       "file",
+			Path:       "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
+			Start:      124,
+			Bytes:      12352,
+			Compressed: false,
+		},
+		`file TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 124 12352`,
+	},
+	{
+		&adc.GetRequest{
+			Type:       "file",
+			Path:       "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
+			Start:      124,
+			Bytes:      12352,
+			Compressed: true,
+		},
+		`file TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 124 12352 ZL1`,
+	},
+	{
+		&adc.GetRequest{
+			Type:       "tthl",
+			Path:       "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
+			Start:      124,
+			Bytes:      12352,
+			Compressed: false,
+		},
+		`tthl TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 124 12352`,
 	},
 }
 


### PR DESCRIPTION
This patch adds supporto for the "ZL1" prefix at the end of a GET or a SND message.
