### PR TITLE
adc: support hub info

### DIFF
--- a/adc/packets.go
+++ b/adc/packets.go
@@ -150,6 +150,17 @@ func (p *InfoPacket) SetMessage(m Message) {
 }
 
 func (p *InfoPacket) DecodeMessage() error {
+	// special case: hub info
+	infoType := MsgType{'I', 'N', 'F'}
+	if p.Msg.Cmd() == infoType {
+		msg := HubInfo{}
+		if err := Unmarshal(p.Msg.(*RawMessage).Data, &msg); err != nil {
+			return err
+		}
+		p.Msg = msg
+		return nil
+	}
+
 	return decodeMessage(&p.Msg)
 }
 


### PR DESCRIPTION
This patch implements decoding of HubInfo.
HubInfo is normally sent with a IINF; at the moment it cannot be decoded, since INF is associated with UserInfo (sent with BINF).
Since IINF is used exclusively with HubInfo, a solution could consist in switching to HubInfo in this single case, leaving the default behavior in any other case.

