### PR TITLE
adc: register message CMD

### DIFF
--- a/adc/hub.go
+++ b/adc/hub.go
@@ -9,6 +9,7 @@ import (
 
 func init() {
 	RegisterMessage(SIDAssign{})
+	RegisterMessage(UserCommand{})
 	RegisterMessage(GetPassword{})
 	RegisterMessage(Password{})
 	RegisterMessage(Disconnect{})


### PR DESCRIPTION
This patch correctly registers CMD (UserCommand), such that it can be decoded.
