### PR TITLE
adc, nmdc: remove useless interface checks

### DIFF
--- a/adc/chat.go
+++ b/adc/chat.go
@@ -4,10 +4,6 @@ func init() {
 	RegisterMessage(ChatMessage{})
 }
 
-var (
-	_ Message = ChatMessage{}
-)
-
 type ChatMessage struct {
 	Text string `adc:"#"`
 	PM   *SID   `adc:"PM"`

--- a/adc/connect.go
+++ b/adc/connect.go
@@ -5,8 +5,6 @@ func init() {
 	RegisterMessage(ConnectRequest{})
 }
 
-var _ Message = RevConnectRequest{}
-
 type RevConnectRequest struct {
 	Proto string `adc:"#"`
 	Token string `adc:"#"`
@@ -15,8 +13,6 @@ type RevConnectRequest struct {
 func (RevConnectRequest) Cmd() MsgType {
 	return MsgType{'R', 'C', 'M'}
 }
-
-var _ Message = ConnectRequest{}
 
 type ConnectRequest struct {
 	Proto string `adc:"#"`

--- a/adc/files.go
+++ b/adc/files.go
@@ -10,8 +10,6 @@ func init() {
 	RegisterMessage(GetResponse{})
 }
 
-var _ Message = GetInfoRequest{}
-
 type GetInfoRequest struct {
 	Type string `adc:"#"`
 	Path string `adc:"#"`
@@ -20,8 +18,6 @@ type GetInfoRequest struct {
 func (GetInfoRequest) Cmd() MsgType {
 	return MsgType{'G', 'F', 'I'}
 }
-
-var _ Message = GetRequest{}
 
 type GetRequest struct {
 	Type  string `adc:"#"`
@@ -33,8 +29,6 @@ type GetRequest struct {
 func (GetRequest) Cmd() MsgType {
 	return MsgType{'G', 'E', 'T'}
 }
-
-var _ Message = GetResponse{}
 
 type GetResponse GetRequest
 

--- a/adc/hub.go
+++ b/adc/hub.go
@@ -15,7 +15,6 @@ func init() {
 }
 
 var (
-	_ Message     = SIDAssign{}
 	_ Marshaler   = SIDAssign{}
 	_ Unmarshaler = (*SIDAssign)(nil)
 )
@@ -35,8 +34,6 @@ func (m SIDAssign) MarshalADC(buf *bytes.Buffer) error {
 func (m *SIDAssign) UnmarshalADC(data []byte) error {
 	return m.SID.UnmarshalADC(data)
 }
-
-var _ Message = UserCommand{}
 
 type Category int
 
@@ -63,7 +60,6 @@ func (UserCommand) Cmd() MsgType {
 var base32Enc = base32.StdEncoding.WithPadding(base32.NoPadding)
 
 var (
-	_ Message     = GetPassword{}
 	_ Marshaler   = GetPassword{}
 	_ Unmarshaler = (*GetPassword)(nil)
 )
@@ -91,8 +87,6 @@ func (m *GetPassword) UnmarshalADC(data []byte) error {
 	return err
 }
 
-var _ Message = Password{}
-
 type Password struct {
 	Hash tiger.Hash `adc:"#"`
 }
@@ -100,10 +94,6 @@ type Password struct {
 func (Password) Cmd() MsgType {
 	return MsgType{'P', 'A', 'S'}
 }
-
-var (
-	_ Message = Disconnect{}
-)
 
 type Disconnect struct {
 	ID       SID    `adc:"#"`

--- a/adc/messages.go
+++ b/adc/messages.go
@@ -52,7 +52,6 @@ func UnmarshalMessage(name MsgType, data []byte) (Message, error) {
 }
 
 var (
-	_ Message     = (*RawMessage)(nil)
 	_ Marshaler   = (*RawMessage)(nil)
 	_ Unmarshaler = (*RawMessage)(nil)
 )
@@ -149,7 +148,6 @@ func (f *Fields) UnmarshalADC(data []byte) error {
 }
 
 var (
-	_ Message     = Supported{}
 	_ Marshaler   = Supported{}
 	_ Unmarshaler = (*Supported)(nil)
 )
@@ -179,7 +177,6 @@ const (
 )
 
 var (
-	_ Message     = Status{}
 	_ Marshaler   = Status{}
 	_ Unmarshaler = (*Status)(nil)
 )
@@ -234,7 +231,6 @@ func (st *Status) UnmarshalADC(s []byte) error {
 }
 
 var (
-	_ Message     = ZOn{}
 	_ Marshaler   = ZOn{}
 	_ Unmarshaler = (*ZOn)(nil)
 )
@@ -248,7 +244,6 @@ func (ZOn) Cmd() MsgType {
 }
 
 var (
-	_ Message     = ZOff{}
 	_ Marshaler   = ZOff{}
 	_ Unmarshaler = (*ZOff)(nil)
 )

--- a/adc/packets.go
+++ b/adc/packets.go
@@ -131,8 +131,6 @@ func DecodePacketRaw(p []byte) (Packet, error) {
 	return m, nil
 }
 
-var _ Packet = (*InfoPacket)(nil)
-
 type InfoPacket struct {
 	Msg Message
 }
@@ -192,8 +190,6 @@ func (p *InfoPacket) UnmarshalPacketADC(name MsgType, data []byte) error {
 	p.Msg = &RawMessage{Type: name, Data: data}
 	return nil
 }
-
-var _ Packet = (*HubPacket)(nil)
 
 type HubPacket InfoPacket
 
@@ -533,8 +529,6 @@ func (p *EchoPacket) UnmarshalPacketADC(name MsgType, data []byte) error {
 	return nil
 }
 
-var _ Packet = (*ClientPacket)(nil)
-
 type ClientPacket struct {
 	Msg Message
 }
@@ -730,8 +724,6 @@ func (p *FeaturePacket) UnmarshalPacketADC(name MsgType, data []byte) error {
 	p.Msg = &RawMessage{Type: name, Data: data}
 	return nil
 }
-
-var _ Packet = (*UDPPacket)(nil)
 
 type UDPPacket struct {
 	ID  CID

--- a/adc/search.go
+++ b/adc/search.go
@@ -28,8 +28,6 @@ const (
 	FileTypeDir  FileType = 2
 )
 
-var _ Message = SearchRequest{}
-
 type SearchRequest struct {
 	Token string   `adc:"TO"`
 	And   []string `adc:"AN"`
@@ -53,8 +51,6 @@ type SearchRequest struct {
 func (SearchRequest) Cmd() MsgType {
 	return MsgType{'S', 'C', 'H'}
 }
-
-var _ Message = SearchResult{}
 
 type SearchResult struct {
 	Token string `adc:"TO"`

--- a/adc/user.go
+++ b/adc/user.go
@@ -11,7 +11,6 @@ func init() {
 }
 
 var (
-	_ Message     = UserInfoMod{}
 	_ Marshaler   = UserInfoMod{}
 	_ Unmarshaler = (*UserInfoMod)(nil)
 )
@@ -53,8 +52,6 @@ const (
 	AwayTypeNormal   AwayType = 1
 	AwayTypeExtended AwayType = 2
 )
-
-var _ Message = UserInfo{}
 
 type UserInfo struct {
 	Id   CID    `adc:"ID"`
@@ -112,8 +109,6 @@ func (u *UserInfo) Normalize() {
 		}
 	}
 }
-
-var _ Message = HubInfo{}
 
 type HubInfo struct {
 	Name        string   `adc:"NI,req"`

--- a/nmdc/message.go
+++ b/nmdc/message.go
@@ -78,8 +78,6 @@ func IsRegistered(typ string) bool {
 	return ok
 }
 
-var _ Message = (*RawMessage)(nil)
-
 // RawMessage is a raw NMDC message in the connection encoding.
 type RawMessage struct {
 	Typ  string

--- a/nmdc/ops.go
+++ b/nmdc/ops.go
@@ -8,8 +8,6 @@ func init() {
 	RegisterMessage(&ForceMove{})
 }
 
-var _ Message = (*ForceMove)(nil)
-
 type ForceMove struct {
 	Address string
 }


### PR DESCRIPTION
This patch removes a series of useless interface checks:
* it's useless to check whether messages implement interface Message, since RegisterMessage() already does
* it's useless to check whether packets implement interface Packet, since DecodePacketRaw() already does
