### PR TITLE
adc: split tests into separate files and use same test cases for marshaling and unmarshaling

### DIFF
--- a/adc/chat_test.go
+++ b/adc/chat_test.go
@@ -1,0 +1,31 @@
+package adc
+
+import (
+	"testing"
+)
+
+var chatCases = []casesMessageEntry{
+	{
+		"msg",
+		`some\stext`,
+		&ChatMessage{Text: "some text"},
+	},
+	{
+		"pm",
+		`some\stext PMAAAB`,
+		&ChatMessage{Text: "some text", PM: sidp("AAAB")},
+	},
+	{
+		"me",
+		`some\stext ME1`,
+		&ChatMessage{Text: "some text", Me: true},
+	},
+}
+
+func TestChatUnmarshal(t *testing.T) {
+	doMessageTestUnmarshal(t, chatCases)
+}
+
+func TestChatMarshal(t *testing.T) {
+	doMessageTestMarshal(t, chatCases)
+}

--- a/adc/connect_test.go
+++ b/adc/connect_test.go
@@ -1,0 +1,26 @@
+package adc
+
+import (
+	"testing"
+)
+
+var connectCases = []casesMessageEntry{
+	{
+		"connect request",
+		`ADC/1.0 3000 1298498081`,
+		&ConnectRequest{Proto: "ADC/1.0", Port: 3000, Token: "1298498081"},
+	},
+	{
+		"rev connect request",
+		`ADC/1.0 12345678`,
+		&RevConnectRequest{Proto: "ADC/1.0", Token: "12345678"},
+	},
+}
+
+func TestConnectUnmarshal(t *testing.T) {
+	doMessageTestUnmarshal(t, connectCases)
+}
+
+func TestConnectMarshal(t *testing.T) {
+	doMessageTestMarshal(t, connectCases)
+}

--- a/adc/files_test.go
+++ b/adc/files_test.go
@@ -1,0 +1,49 @@
+package adc
+
+import (
+	"testing"
+)
+
+var filesCases = []casesMessageEntry{
+	{
+		"get file",
+		`file TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 124 12352`,
+		&GetRequest{
+			Type:       "file",
+			Path:       "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
+			Start:      124,
+			Bytes:      12352,
+			Compressed: false,
+		},
+	},
+	{
+		"get file compressed",
+		`file TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 124 12352 ZL1`,
+		&GetRequest{
+			Type:       "file",
+			Path:       "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
+			Start:      124,
+			Bytes:      12352,
+			Compressed: true,
+		},
+	},
+	{
+		"get tthl",
+		`tthl TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 124 12352`,
+		&GetRequest{
+			Type:       "tthl",
+			Path:       "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
+			Start:      124,
+			Bytes:      12352,
+			Compressed: false,
+		},
+	},
+}
+
+func TestFilesUnmarshal(t *testing.T) {
+	doMessageTestUnmarshal(t, filesCases)
+}
+
+func TestFilesMarshal(t *testing.T) {
+	doMessageTestMarshal(t, filesCases)
+}

--- a/adc/hub_test.go
+++ b/adc/hub_test.go
@@ -1,0 +1,37 @@
+package adc
+
+import (
+	"testing"
+
+	"github.com/direct-connect/go-dc/tiger"
+)
+
+var hubCases = []casesMessageEntry{
+	{
+		"user command",
+		`ADCH++/Hub\smanagement/Reload\sscripts TTHMSG\s+reload\n CT3`,
+		&UserCommand{
+			Path:     Path{"ADCH++", "Hub management", "Reload scripts"},
+			Command:  "HMSG +reload\n",
+			Category: CategoryHub | CategoryUser,
+		},
+	},
+	{
+		"get password",
+		`AAAQEAYEAUDAOCAJAAAQEAYCAMCAKBQHBAEQAAI`,
+		&GetPassword{Salt: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1}},
+	},
+	{
+		"password",
+		`ABZCJESSJKVMIL2BDERHSJ7RF5IYI6ZX2QAOQGI`,
+		&Password{Hash: tiger.HashBytes([]byte("qwerty"))},
+	},
+}
+
+func TestHubUnmarshal(t *testing.T) {
+	doMessageTestUnmarshal(t, hubCases)
+}
+
+func TestHubMarshal(t *testing.T) {
+	doMessageTestMarshal(t, hubCases)
+}

--- a/adc/marshal_test.go
+++ b/adc/marshal_test.go
@@ -1,165 +1,29 @@
-package adc_test
+package adc
 
 import (
 	"bytes"
 	"reflect"
 	"testing"
 
-	"github.com/direct-connect/go-dc/adc"
 	"github.com/direct-connect/go-dc/adc/types"
-	"github.com/direct-connect/go-dc/tiger"
+	"github.com/stretchr/testify/require"
 )
 
-var casesDecode = []struct {
-	name   string
-	data   string
-	expect interface{}
-}{
-	{
-		"user",
-		`NIgopher SF34 FS0 SUGCON,ADC0 SS39542721391 VEGoConn\s0.01 SL3 IDHVBNEMDCTKCD4V3N54X4MMOVLJLJL6PSKVHFXHI I4172.17.42.1`,
-		&adc.UserInfo{
-			Id:         types.MustParseCID(`HVBNEMDCTKCD4V3N54X4MMOVLJLJL6PSKVHFXHI`),
-			Name:       "gopher",
-			Ip4:        "172.17.42.1",
-			ShareFiles: 34, ShareSize: 39542721391,
-			Version:  `GoConn 0.01`,
-			Slots:    3,
-			Features: adc.ExtFeatures{{'G', 'C', 'O', 'N'}, {'A', 'D', 'C', '0'}},
-		},
-	},
-	{
-		"user id",
-		`PDHVBNEMDCTKCD4V3N54X4MMOVLJLJL6PSKVHFXHI NIgopher SF34 FS0 SUGCON,ADC0 SS39542721391 VEGoConn\s0.01 SL3 IDHVBNEMDCTKCD4V3N54X4MMOVLJLJL6PSKVHFXHI I4172.17.42.1`,
-		&adc.UserInfo{
-			Id:         types.MustParseCID(`HVBNEMDCTKCD4V3N54X4MMOVLJLJL6PSKVHFXHI`),
-			Pid:        types.MustParseCIDP(`HVBNEMDCTKCD4V3N54X4MMOVLJLJL6PSKVHFXHI`),
-			Name:       "gopher",
-			Ip4:        "172.17.42.1",
-			ShareFiles: 34, ShareSize: 39542721391,
-			Version:  `GoConn 0.01`,
-			Slots:    3,
-			Features: adc.ExtFeatures{{'G', 'C', 'O', 'N'}, {'A', 'D', 'C', '0'}},
-		},
-	},
-	{
-		"user pid",
-		`IDKAY6BI76T6XFIQXZNRYE4WXJ2Y3YGXJG7UM7XLI NIuser SL3 FS3 SS25146919163 SF23 HR0 HO1 VEEiskaltDC++\s2.2.9 US1310720 KPSHA256/C44JWX62IN6JBAVH7NIHEZIQ6WSNQ2LHTOWYWP7ADGAYTCPZVWRQ U43000 SUSEGA,ADC0,TCP4,UDP4 I4172.17.42.1 HN11`,
-		&adc.UserInfo{
-			Id:         types.MustParseCID(`KAY6BI76T6XFIQXZNRYE4WXJ2Y3YGXJG7UM7XLI`),
-			Name:       "user",
-			Ip4:        "172.17.42.1",
-			ShareFiles: 23, ShareSize: 25146919163,
-			Version:   `EiskaltDC++ 2.2.9`,
-			Udp4:      3000,
-			MaxUpload: "1310720", Slots: 3, SlotsFree: 3,
-			HubsNormal: 11, HubsOperator: 1,
-			Features: adc.ExtFeatures{{'S', 'E', 'G', 'A'}, {'A', 'D', 'C', '0'}, {'T', 'C', 'P', '4'}, {'U', 'D', 'P', '4'}},
-			KP:       "SHA256/C44JWX62IN6JBAVH7NIHEZIQ6WSNQ2LHTOWYWP7ADGAYTCPZVWRQ",
-		},
-	},
-	{
-		"user no name",
-		`SF8416 HN18 FS1 U4 SS34815324082 HO2 SUNAT0,ADC0,SEGA`,
-		&adc.UserInfo{
-			ShareFiles: 8416, ShareSize: 34815324082,
-			HubsNormal: 18, HubsOperator: 2,
-			SlotsFree: 1, Udp4: 0,
-			Features: adc.ExtFeatures{{'N', 'A', 'T', '0'}, {'A', 'D', 'C', '0'}, {'S', 'E', 'G', 'A'}},
-		},
-	},
-	{
-		"get password",
-		`AAAQEAYEAUDAOCAJAAAQEAYCAMCAKBQHBAEQAAI`,
-		&adc.GetPassword{Salt: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1}},
-	},
-	{
-		"password",
-		`ABZCJESSJKVMIL2BDERHSJ7RF5IYI6ZX2QAOQGI`,
-		&adc.Password{Hash: tiger.HashBytes([]byte("qwerty"))},
-	},
-	{
-		"search res",
-		`TOtok FNfilepath SI1234567 SL3`,
-		&adc.SearchResult{Path: "filepath", Size: 1234567, Slots: 3, Token: "tok"},
-	},
-	{
-		"search par",
-		`TO4171511714 ANsome ANdata GR32`,
-		&adc.SearchRequest{And: []string{"some", "data"}, Token: "4171511714", Group: adc.ExtVideo},
-	},
-	{
-		"search par2",
-		`TO4171511714 GR32`,
-		&adc.SearchRequest{Token: "4171511714", Group: adc.ExtVideo},
-	},
-	{
-		"search par3",
-		`TO4171511714 ANsome ANdata`,
-		&adc.SearchRequest{And: []string{"some", "data"}, Token: "4171511714"},
-	},
-	{
-		"rcm resp",
-		`ADC/1.0 3000 1298498081`,
-		&adc.ConnectRequest{Proto: "ADC/1.0", Port: 3000, Token: "1298498081"},
-	},
-	{
-		"msg",
-		`some\stext`,
-		&adc.ChatMessage{Text: "some text"},
-	},
-	{
-		"pm",
-		`some\stext PMAAAB`,
-		&adc.ChatMessage{Text: "some text", PM: sidp("AAAB")},
-	},
-	{
-		"me",
-		`some\stext ME1`,
-		&adc.ChatMessage{Text: "some text", Me: true},
-	},
-	{
-		"user command",
-		`ADCH++/Hub\smanagement/Reload\sscripts TTHMSG\s+reload\n CT3`,
-		&adc.UserCommand{
-			Path:     adc.Path{"ADCH++", "Hub management", "Reload scripts"},
-			Command:  "HMSG +reload\n",
-			Category: adc.CategoryHub | adc.CategoryUser,
-		},
-	},
-	{
-		"get file",
-		`file TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 124 12352`,
-		&adc.GetRequest{
-			Type:       "file",
-			Path:       "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
-			Start:      124,
-			Bytes:      12352,
-			Compressed: false,
-		},
-	},
-	{
-		"get file compressed",
-		`file TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 124 12352 ZL1`,
-		&adc.GetRequest{
-			Type:       "file",
-			Path:       "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
-			Start:      124,
-			Bytes:      12352,
-			Compressed: true,
-		},
-	},
-	{
-		"get tthl",
-		`tthl TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 124 12352`,
-		&adc.GetRequest{
-			Type:       "tthl",
-			Path:       "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
-			Start:      124,
-			Bytes:      12352,
-			Compressed: false,
-		},
-	},
+func TestSIDMarshal(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	err := types.SIDFromString("AAAA").MarshalADC(buf)
+	require.NoError(t, err)
+	require.Equal(t, "AAAA", buf.String())
+
+	buf = bytes.NewBuffer(nil)
+	err = types.SIDFromInt(2).MarshalADC(buf)
+	require.NoError(t, err)
+	require.Equal(t, "AAAC", buf.String())
+
+	buf = bytes.NewBuffer(nil)
+	err = types.SIDFromInt(34).MarshalADC(buf)
+	require.NoError(t, err)
+	require.Equal(t, "AABC", buf.String())
 }
 
 func sidp(s string) *types.SID {
@@ -167,144 +31,30 @@ func sidp(s string) *types.SID {
 	return &v
 }
 
-func TestDecode(t *testing.T) {
-	for _, c := range casesDecode {
+type casesMessageEntry struct {
+	name string
+	data string
+	msg  Message
+}
+
+func doMessageTestUnmarshal(t *testing.T, cases []casesMessageEntry) {
+	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			targ := reflect.New(reflect.TypeOf(c.expect).Elem()).Interface()
-			err := adc.Unmarshal([]byte(c.data), targ)
-			if err != nil {
-				t.Fatal(err)
-			} else if !reflect.DeepEqual(targ, c.expect) {
-				t.Fatalf("\n%#v\nvs\n%#v", targ, c.expect)
-			}
+			targ := reflect.New(reflect.TypeOf(c.msg).Elem()).Interface()
+			err := Unmarshal([]byte(c.data), targ)
+			require.NoError(t, err)
+			require.Equal(t, c.msg, targ)
 		})
 	}
 }
 
-var casesEncode = []struct {
-	input  interface{}
-	expect string
-}{
-	{
-		types.SIDFromString("AAAA"),
-		"AAAA",
-	},
-	{
-		types.SIDFromInt(2),
-		"AAAC",
-	},
-	{
-		types.SIDFromInt(34),
-		"AABC",
-	},
-	{
-		adc.UserInfo{
-			Id:         types.MustParseCID(`KAY6BI76T6XFIQXZNRYE4WXJ2Y3YGXJG7UM7XLI`),
-			Name:       "user",
-			Ip4:        "172.17.42.1",
-			ShareFiles: 23, ShareSize: 25146919163,
-			Version:  `EiskaltDC++ 2.2.9`,
-			Features: adc.ExtFeatures{{'S', 'E', 'G', 'A'}, {'A', 'D', 'C', '0'}, {'T', 'C', 'P', '4'}, {'U', 'D', 'P', '4'}},
-		},
-		`IDKAY6BI76T6XFIQXZNRYE4WXJ2Y3YGXJG7UM7XLI NIuser I4172.17.42.1 SS25146919163 SF23 VEEiskaltDC++\s2.2.9 SL0 FS0 HN0 HR0 HO0 SUSEGA,ADC0,TCP4,UDP4`,
-	},
-	{
-		adc.GetPassword{Salt: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1}},
-		`AAAQEAYEAUDAOCAJAAAQEAYCAMCAKBQHBAEQAAI`,
-	},
-	{
-		adc.Password{Hash: tiger.HashBytes([]byte("qwerty"))},
-		`ABZCJESSJKVMIL2BDERHSJ7RF5IYI6ZX2QAOQGI`,
-	},
-	{
-		adc.SearchRequest{And: []string{"some", "data"}, Token: "4171511714", Group: adc.ExtVideo},
-		`TO4171511714 ANsome ANdata GR32`,
-	},
-	{
-		adc.SearchResult{Path: "filepath", Size: 1234567, Slots: 3, Token: "tok"},
-		`TOtok FNfilepath SI1234567 SL3`,
-	},
-	{
-		adc.SearchRequest{And: []string{"some", "data"}, Token: "4171511714", Group: adc.ExtVideo},
-		`TO4171511714 ANsome ANdata GR32`,
-	},
-	{
-		adc.SearchRequest{Token: "4171511714", Group: adc.ExtVideo},
-		`TO4171511714 GR32`,
-	},
-	{
-		adc.SearchRequest{And: []string{"some", "data"}, Token: "4171511714"},
-		`TO4171511714 ANsome ANdata`,
-	},
-	{
-		adc.RevConnectRequest{Proto: `ADC/1.0`, Token: `12345678`},
-		`ADC/1.0 12345678`,
-	},
-	{
-		&adc.ChatMessage{Text: "some text", PM: sidp("AAAB")},
-		`some\stext PMAAAB`,
-	},
-	{
-		&adc.ChatMessage{Text: "some text", Me: true},
-		`some\stext ME1`,
-	},
-	{
-		adc.UserCommand{
-			Path:     adc.Path{"ADCH++", "Hub management", "Reload scripts"},
-			Command:  "HMSG +reload\n",
-			Category: adc.CategoryHub | adc.CategoryUser,
-		},
-		`ADCH++/Hub\smanagement/Reload\sscripts TTHMSG\s+reload\n CT3`,
-	},
-	{
-		&adc.GetRequest{
-			Type:       "file",
-			Path:       "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
-			Start:      124,
-			Bytes:      12352,
-			Compressed: false,
-		},
-		`file TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 124 12352`,
-	},
-	{
-		&adc.GetRequest{
-			Type:       "file",
-			Path:       "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
-			Start:      124,
-			Bytes:      12352,
-			Compressed: true,
-		},
-		`file TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 124 12352 ZL1`,
-	},
-	{
-		&adc.GetRequest{
-			Type:       "tthl",
-			Path:       "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
-			Start:      124,
-			Bytes:      12352,
-			Compressed: false,
-		},
-		`tthl TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 124 12352`,
-	},
-}
-
-func TestEncode(t *testing.T) {
-	for i, c := range casesEncode {
-		buf := bytes.NewBuffer(nil)
-		var err error
-		if msg, ok := c.input.(adc.Message); !ok {
-			if m, ok := c.input.(adc.Marshaler); ok {
-				err = m.MarshalADC(buf)
-			} else {
-				t.Fatalf("unsupported type: %T", c.input)
-			}
-		} else {
-			err = adc.Marshal(buf, msg)
-		}
-		if err != nil {
-			t.Fatalf("case %d: %v", i+1, err)
-		} else if got := buf.String(); got != c.expect {
-			t.Fatalf("case %d: failed:\n%#v\nvs\n%#v", i+1, got, c.expect)
-		}
+func doMessageTestMarshal(t *testing.T, cases []casesMessageEntry) {
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			err := Marshal(buf, c.msg)
+			require.NoError(t, err)
+			require.Equal(t, c.data, buf.String())
+		})
 	}
 }

--- a/adc/packets_test.go
+++ b/adc/packets_test.go
@@ -1,12 +1,11 @@
-package adc_test
+package adc
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/require"
 	"testing"
 
-	. "github.com/direct-connect/go-dc/adc"
 	"github.com/direct-connect/go-dc/adc/types"
+	"github.com/stretchr/testify/require"
 )
 
 const delim = "\n"

--- a/adc/search_test.go
+++ b/adc/search_test.go
@@ -1,0 +1,36 @@
+package adc
+
+import (
+	"testing"
+)
+
+var searchCases = []casesMessageEntry{
+	{
+		"search res",
+		`TOtok FNfilepath SI1234567 SL3`,
+		&SearchResult{Path: "filepath", Size: 1234567, Slots: 3, Token: "tok"},
+	},
+	{
+		"search par",
+		`TO4171511714 ANsome ANdata GR32`,
+		&SearchRequest{And: []string{"some", "data"}, Token: "4171511714", Group: ExtVideo},
+	},
+	{
+		"search par2",
+		`TO4171511714 GR32`,
+		&SearchRequest{Token: "4171511714", Group: ExtVideo},
+	},
+	{
+		"search par3",
+		`TO4171511714 ANsome ANdata`,
+		&SearchRequest{And: []string{"some", "data"}, Token: "4171511714"},
+	},
+}
+
+func TestSearchUnmarshal(t *testing.T) {
+	doMessageTestUnmarshal(t, searchCases)
+}
+
+func TestSearchMarshal(t *testing.T) {
+	doMessageTestMarshal(t, searchCases)
+}

--- a/adc/user_test.go
+++ b/adc/user_test.go
@@ -1,0 +1,80 @@
+package adc
+
+import (
+	"testing"
+
+	"github.com/direct-connect/go-dc/adc/types"
+)
+
+var userCases = []casesMessageEntry{
+	{
+		"user",
+		`IDHVBNEMDCTKCD4V3N54X4MMOVLJLJL6PSKVHFXHI NIgopher I4172.17.42.1 SS39542721391 SF34 VEGoConn\s0.01 SL3 FS0 HN0 HR0 HO0 SUGCON,ADC0`,
+		&UserInfo{
+			Id:         types.MustParseCID(`HVBNEMDCTKCD4V3N54X4MMOVLJLJL6PSKVHFXHI`),
+			Name:       "gopher",
+			Ip4:        "172.17.42.1",
+			ShareFiles: 34,
+			ShareSize:  39542721391,
+			Version:    `GoConn 0.01`,
+			Slots:      3,
+			Features:   ExtFeatures{{'G', 'C', 'O', 'N'}, {'A', 'D', 'C', '0'}},
+		},
+	},
+	{
+		"user id",
+		`IDHVBNEMDCTKCD4V3N54X4MMOVLJLJL6PSKVHFXHI PDHVBNEMDCTKCD4V3N54X4MMOVLJLJL6PSKVHFXHI NIgopher I4172.17.42.1 SS39542721391 SF34 VEGoConn\s0.01 SL3 FS0 HN0 HR0 HO0 SUGCON,ADC0`,
+		&UserInfo{
+			Id:         types.MustParseCID(`HVBNEMDCTKCD4V3N54X4MMOVLJLJL6PSKVHFXHI`),
+			Pid:        types.MustParseCIDP(`HVBNEMDCTKCD4V3N54X4MMOVLJLJL6PSKVHFXHI`),
+			Name:       "gopher",
+			Ip4:        "172.17.42.1",
+			ShareFiles: 34,
+			ShareSize:  39542721391,
+			Version:    `GoConn 0.01`,
+			Slots:      3,
+			Features:   ExtFeatures{{'G', 'C', 'O', 'N'}, {'A', 'D', 'C', '0'}},
+		},
+	},
+	{
+		"user pid",
+		`IDKAY6BI76T6XFIQXZNRYE4WXJ2Y3YGXJG7UM7XLI NIuser I4172.17.42.1 U43000 SS25146919163 SF23 VEEiskaltDC++\s2.2.9 US1310720 SL3 FS3 HN11 HR0 HO1 SUSEGA,ADC0,TCP4,UDP4 KPSHA256/C44JWX62IN6JBAVH7NIHEZIQ6WSNQ2LHTOWYWP7ADGAYTCPZVWRQ`,
+		&UserInfo{
+			Id:           types.MustParseCID(`KAY6BI76T6XFIQXZNRYE4WXJ2Y3YGXJG7UM7XLI`),
+			Name:         "user",
+			Ip4:          "172.17.42.1",
+			ShareFiles:   23,
+			ShareSize:    25146919163,
+			Version:      `EiskaltDC++ 2.2.9`,
+			Udp4:         3000,
+			MaxUpload:    "1310720",
+			Slots:        3,
+			SlotsFree:    3,
+			HubsNormal:   11,
+			HubsOperator: 1,
+			Features:     ExtFeatures{{'S', 'E', 'G', 'A'}, {'A', 'D', 'C', '0'}, {'T', 'C', 'P', '4'}, {'U', 'D', 'P', '4'}},
+			KP:           "SHA256/C44JWX62IN6JBAVH7NIHEZIQ6WSNQ2LHTOWYWP7ADGAYTCPZVWRQ",
+		},
+	},
+	{
+		"user no name",
+		`NI SS34815324082 SF8416 VE SL0 FS1 HN18 HR0 HO2 SUNAT0,ADC0,SEGA`,
+		&UserInfo{
+			ShareFiles:   8416,
+			ShareSize:    34815324082,
+			HubsNormal:   18,
+			HubsOperator: 2,
+			SlotsFree:    1,
+			Udp4:         0,
+			Features:     ExtFeatures{{'N', 'A', 'T', '0'}, {'A', 'D', 'C', '0'}, {'S', 'E', 'G', 'A'}},
+		},
+	},
+}
+
+func TestUserUnmarshal(t *testing.T) {
+	doMessageTestUnmarshal(t, userCases)
+}
+
+func TestUserMarshal(t *testing.T) {
+	doMessageTestMarshal(t, userCases)
+}


### PR DESCRIPTION
this patch:
* splits message tests into separate files, so it's much easier to check whether a message has tests or not
* improves marshal and unmarshal tests in order to use the same test cases for both (previously there were two test cases)
