### PR TITLE
adc: fix SND marshaling/unmarshaling

### DIFF
--- a/adc/files.go
+++ b/adc/files.go
@@ -109,3 +109,11 @@ type GetResponse GetRequest
 func (GetResponse) Cmd() MsgType {
 	return MsgType{'S', 'N', 'D'}
 }
+
+func (m GetResponse) MarshalADC(buf *bytes.Buffer) error {
+	return GetRequest(m).MarshalADC(buf)
+}
+
+func (m *GetResponse) UnmarshalADC(data []byte) error {
+	return (*GetRequest)(m).UnmarshalADC(data)
+}

--- a/adc/files_test.go
+++ b/adc/files_test.go
@@ -38,6 +38,17 @@ var filesCases = []casesMessageEntry{
 			Compressed: false,
 		},
 	},
+	{
+		"get response",
+		`file TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 124 12352 ZL1`,
+		&GetResponse{
+			Type:       "file",
+			Path:       "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
+			Start:      124,
+			Bytes:      12352,
+			Compressed: true,
+		},
+	},
 }
 
 func TestFilesUnmarshal(t *testing.T) {


### PR DESCRIPTION
WARNING: this requires #33 

This patch fixes SND parsing, since MarshalADC and UnmarshalADC were not inherited from GET, and adds unit tests.
