### PR TITLE
nmdc: support DownloadedBytes field in ADCGET

### DIFF
--- a/nmdc/files_test.go
+++ b/nmdc/files_test.go
@@ -47,6 +47,38 @@ var filesCases = []casesMessageEntry{
 		},
 	},
 	{
+		typ:  "ADCGET",
+		data: `file TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 123523 65 ZL1 DB15`,
+		msg: &ADCGet{
+			ContentType: "file",
+			Identifier:  "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
+			Start:       123523,
+			Length:      65,
+			Compressed:  true,
+			DownloadedBytes: func() *uint64 {
+				ret := new(uint64)
+				*ret = 15
+				return ret
+			}(),
+		},
+	},
+	{
+		typ:  "ADCGET",
+		data: `file TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 123523 65 DB15`,
+		msg: &ADCGet{
+			ContentType: "file",
+			Identifier:  "TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI",
+			Start:       123523,
+			Length:      65,
+			Compressed:  false,
+			DownloadedBytes: func() *uint64 {
+				ret := new(uint64)
+				*ret = 15
+				return ret
+			}(),
+		},
+	},
+	{
 		typ:  "ADCSND",
 		data: `file TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 123523 65`,
 		msg: &ADCSnd{


### PR DESCRIPTION
Hello, i've discovered that the NMDC ADCGet message has an obscure additional field called <i>downloaded bytes</i>, used by some older clients (ApexDC++ and probably others).
It is inserted at the end of the command, prefixed by DB:
```
$ADCGet file TTH/BR4BVJBMHDFVCFI4WBPSL63W5TWXWVBSC574BLI 123523 65 ZL1 DB15
```

Since go-dc performs a very strict decoding, any ADCGet message sent by ApexDC++ is rejected,  and file uploads are not possible.

This patch adds support for this field.